### PR TITLE
Pick up ListMakerTemplate, even if it's off

### DIFF
--- a/ListMaker/ListMaker.csproj
+++ b/ListMaker/ListMaker.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda" Version="0.13.2.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.0.2.1" />
+        <PackageReference Include="Mutagen.Bethesda" Version="0.13.4" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.0.6" />
     </ItemGroup>
 
 </Project>

--- a/ListMaker/Program.cs
+++ b/ListMaker/Program.cs
@@ -30,6 +30,7 @@ namespace ListMaker
                 patcher: RunPatch,
                 new UserPreferences()
                 {
+                    IncludeDisabledMods = true,
                     ActionsForEmptyArgs = new RunDefaultPatcher()
                     {
                         IdentifyingModKey = "ListMaker.esp",
@@ -43,7 +44,7 @@ namespace ListMaker
         {
             var lvliMap = LVLIMap.CreateMap();
 
-            foreach (var leveledList in state.LoadOrder.PriorityOrder.WinningOverrides<ILeveledItemGetter>())
+            foreach (var leveledList in state.LoadOrder.PriorityOrder.OnlyEnabled().WinningOverrides<ILeveledItemGetter>())
             {
                 if (lvliMap.ContainsValue(leveledList.FormKey)) continue;
 


### PR DESCRIPTION
Added a new feature where Synthesis will provide you with all mods listed on the plugin.txt, even if they're turned off.   This is useful for this patcher, specifically, as it will allow it to work even if the user hasn't enabled the template esp.